### PR TITLE
Send default user agent string if not overridden

### DIFF
--- a/itm/itm.go
+++ b/itm/itm.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	libraryName            = "go-itm"
-	libraryVersion         = "0.0.1"
+	libraryVersion         = "1.0.1"
 	libraryURL             = "https://github.com/cedexis/" + libraryName
 	defaultBaseURL         = "https://portal.cedexis.com/api/"
 	defaultUserAgentString = libraryName + "/" + libraryVersion + " (" + libraryURL + ")"

--- a/itm/itm.go
+++ b/itm/itm.go
@@ -49,6 +49,14 @@ func HTTPClient(httpClient *http.Client) ClientOpt {
 	}
 }
 
+// UserAgentString creates a client option used to specify the user-agent HTTP request header
+func UserAgentString(value string) ClientOpt {
+	return func(c *Client) error {
+		c.UserAgentString = value
+		return nil
+	}
+}
+
 func (c *Client) parseOptions(opts ...ClientOpt) error {
 	for _, option := range opts {
 		err := option(c)
@@ -63,7 +71,8 @@ func (c *Client) parseOptions(opts ...ClientOpt) error {
 func NewClient(opts ...ClientOpt) (*Client, error) {
 	baseURL, _ := url.Parse(defaultBaseURL)
 	result := &Client{
-		BaseURL: baseURL,
+		BaseURL:         baseURL,
+		UserAgentString: defaultUserAgentString,
 	}
 	result.DNSApps = &dnsAppsServiceImpl{client: result}
 	if err := result.parseOptions(opts...); err != nil {

--- a/itm/utilities.go
+++ b/itm/utilities.go
@@ -2,13 +2,7 @@ package itm
 
 import (
 	"fmt"
-	"net/url"
 )
-
-func stringToURL(asString string) *url.URL {
-	result, _ := url.Parse(asString)
-	return result
-}
 
 func unexpectedValueString(label string, expected interface{}, got interface{}) string {
 	return fmt.Sprintf("Unexpected value [%s]\nExpected: %v\nGot: %v", label, expected, got)


### PR DESCRIPTION
This is to fix a bug in the go-itm library causing it to fail to send its default user agent string when there is no override provided. I also intend to override it from within the Terraform provider, so we can differentiate between Terraform requests and those of other programs that might also use the go-itm library down the road, but that is a separate issue.