### PR TITLE
Add a Dockerfile for use in local development and testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.11.6-alpine3.9
+
+RUN apk add --update \
+    bash \
+    bash-completion \
+    build-base \
+    shadow
+
+RUN usermod --shell /bin/bash root
+ADD docker/bashrc.sh /root/.bashrc
+
+# Set the default working directory
+WORKDIR /go-itm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
+PKG_NAME=go-itm
+DOCKER_IMAGE_NAME=$(PKG_NAME)
+DOCKER_CONTAINER_NAME=$(PKG_NAME)-container
 
 .PHONY: test
 
@@ -8,3 +11,9 @@ fmt:
 
 test:
 	go test ./...
+
+docker-build:
+	@docker build -t $(DOCKER_IMAGE_NAME) .
+
+docker-run:
+	@docker run -it --rm --mount type=bind,readonly=1,src=$(PWD),dst=/go-itm $(DOCKER_IMAGE_NAME) /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME=go-itm
 DOCKER_IMAGE_NAME=$(PKG_NAME)
-DOCKER_CONTAINER_NAME=$(PKG_NAME)-container
 
 .PHONY: test
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,29 @@
 # go-itm
 
 A Go client library for accessing the Citrix ITM API.
+
+## Running Unit Tests in Docker
+
+go-itm can be updated and tested in isolation on your local machine. A Dockerfile and Make targets are provided to aid in this process.
+
+```bash
+$ make docker-build
+```
+
+This builds a Docker image called go-itm:latest on your system.
+
+```bash
+$ make docker-run
+```
+
+This runs an interactive Bash session within a new Docker container based on the go-itm:latest image.
+
+Within the container:
+
+```bash
+[container] /go-itm $ make test 
+go test ./...
+ok github.com/cedexis/go-itm/itm 0.009s
+```
+
+The /go-itm directory within the container is mounted to the project root directory on the Docker host, so you can iteratively edit code on the host using your favorite editor and then re-run the unit tests inside the container.

--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ A Go client library for accessing the Citrix ITM API.
 
 go-itm can be updated and tested in isolation on your local machine. A Dockerfile and Make targets are provided to aid in this process.
 
+Build a Docker image called go-itm:latest:
+
 ```bash
 $ make docker-build
 ```
 
-This builds a Docker image called go-itm:latest on your system.
+Run an interactive Bash session in a new Docker container based on the go-itm:latest image:
 
 ```bash
 $ make docker-run
 ```
 
-This runs an interactive Bash session within a new Docker container based on the go-itm:latest image.
-
-Within the container:
+Run unit tests within the container:
 
 ```bash
 [container] /go-itm $ make test 

--- a/docker/bashrc.sh
+++ b/docker/bashrc.sh
@@ -1,0 +1,7 @@
+source /etc/profile.d/bash_completion.sh
+PS1="[container] \w $ "
+
+# For ls
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'


### PR DESCRIPTION
This sets up the Docker environment for use as described in README.md and the internal Confluence document called "Updating go-itm".